### PR TITLE
changed behavior so now symbol instances are renamed to the last portion of a symbol master name after the "/"

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ To find your plugins directory...
 
 # Changelog
 
+* **2.4.1** - Now all instances of symbol(s) are renamed to last to portion after last '/'.
 * **2.4** - Added new function to rename all instances of selected symbol(s).
 * **2.3** - Added new function to rename all instances on all pages, except Symbols page. Added fix for when the master for an instance is missing.
 * **2.2** - Added appcast plugin support for Sketch 45 and later. Added new function to rename all instances on current page. New shortcuts.

--- a/Symbol Instance Renamer.sketchplugin/Contents/Sketch/manifest.json
+++ b/Symbol Instance Renamer.sketchplugin/Contents/Sketch/manifest.json
@@ -11,6 +11,15 @@
 			"handler" : "renamePages"
 		},
 		{
+			"name" : "Rename All Instances of Selected Symbol(s) to Portion After Last '/'",
+			"shortcut" : "cmd option shift k",
+			"identifier" : "renamePages",
+			"description" : "Rename All Instances of Selected Symbol(s) to Portion After Last '/'",
+			"script" : "script.cocoascript",
+			"icon" : "icon-sr.png",
+			"handler" : "renameLastSlashPages"
+		},
+		{
 			"name" : "Rename All Instances on All Pages (Except Symbols Page)",
 			"shortcut" : "cmd option shift x",
 			"identifier" : "renamePagesExceptSymbols",
@@ -58,8 +67,8 @@
 		]
 	},
 	"identifier" : "com.sonburn.sketchplugins.symbol-instance-renamer",
-	"version" : "2.4",
-	"description" : "Rename symbol instances to the name of their master.",
+	"version" : "2.4.1",
+	"description" : "Rename symbol instances to the name of their master (Last portion after "/").",
 	"authorEmail" : "jason.burns@synchronoss.com",
 	"name" : "Symbol Instance Renamer",
 	"appcast" : "https://raw.githubusercontent.com/sonburn/symbol-instance-renamer/master/appcast.xml"

--- a/Symbol Instance Renamer.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/Symbol Instance Renamer.sketchplugin/Contents/Sketch/script.cocoascript
@@ -16,6 +16,19 @@ var renamePages = function(context) {
 	context.document.showMessage(count + strRenameSuccess);
 }
 
+var renameLastSlashPages = function(context) {
+	var pages = context.document.pages(),
+		loop = pages.objectEnumerator(),
+		page,
+		count = 0;
+
+	while (page = loop.nextObject()) {
+		count = count + renameInstancesOnPage(page);
+	}
+
+	context.document.showMessage(count + strRenameSuccess);
+}
+
 var renamePagesExceptSymbols = function(context) {
 	var pages = context.document.pages(),
 		loop = pages.objectEnumerator(),
@@ -94,8 +107,11 @@ function renameInstancesOnPage(page) {
 }
 
 function renameInstance(instance) {
-	if (instance.name() != instance.symbolMaster().name().trim()) {
-		instance.setName(instance.symbolMaster().name());
+	var str = instance.symbolMaster().name().trim();
+	var str_array = str.split("/");
+	var simple_name = str_array[str_array.length - 1];
+	if (instance.name() != simple_name.trim()) {
+		instance.setName(simple_name);
 		return true;
 	} else return false;
 }

--- a/appcast.xml
+++ b/appcast.xml
@@ -6,11 +6,11 @@
 		<description>Rename all symbol instances to the name of their master.</description>
 		<language>en</language>
 		<item>
-			<title>Version 2.4</title>
+			<title>Version 2.4.1</title>
 			<description>
 				<![CDATA[
 				<ul>
-				<li>Added new function to rename all instances of selected symbol(s).</li>
+				<li>Added new function to rename all instances of selected symbol(s) to portion after last '/'.</li>
 				</ul>
 				]]>
 			</description>


### PR DESCRIPTION
@sonburn I apologize for any mess I might have created. Ideally we'd give users the ability to choose the desired behavior and choose "The / Full / Name" or simply "Name". 

We can remove if we only want one of the two behaviours but I wanted my intentions to be obvious.
I'll reach out via Slack too :)

![image](https://user-images.githubusercontent.com/1416981/37230075-30d6df3e-23b4-11e8-8a4b-ea78f3af86c2.png)

What do you think?
